### PR TITLE
Pull Docker GPG key from pgp.mit.edu

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,5 +19,5 @@
 
 default['chef-apt-docker']['components'] = %w(main)
 default['chef-apt-docker']['uri'] = 'https://apt.dockerproject.org/repo'
-default['chef-apt-docker']['keyserver'] = 'p80.pool.sks-keyservers.net'
+default['chef-apt-docker']['keyserver'] = 'pgp.mit.edu'
 default['chef-apt-docker']['key'] = '58118E89F3A912897C070ADBF76221572C52609D'


### PR DESCRIPTION
The previous key server `p80.pool.sks-keyservers.net` has been
unavailable multiple times over the past few days.

Signed-off-by: Seth Chisamore <schisamo@chef.io>
