### PR TITLE
updating to the latest docker repo

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -1,7 +1,7 @@
 driver:
   name: dokken
   privileged: true # because Docker and SystemD/Upstart
-  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
+  chef_version: current
 
 transport:
   name: dokken
@@ -16,36 +16,32 @@ verifier:
 platforms:
 - name: debian-7
   driver:
-    image: debian:7
+    image: dokken/debian-7
     pid_one_command: /sbin/init
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
+      - RUN /usr/bin/apt-get install -y init-system-helpers
 
 - name: debian-8
   driver:
-    image: debian:8
+    image: dokken/debian-8
     pid_one_command: /bin/systemd
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
-
+  
 - name: ubuntu-14.04
   driver:
-    image: ubuntu-upstart:14.04
+    image: dokken/ubuntu-14.04
     pid_one_command: /sbin/init
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
 
 - name: ubuntu-16.04
   driver:
-    image: ubuntu:16.04
+    image: dokken/ubuntu-16.04
     pid_one_command: /bin/systemd
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
 
+- name: ubuntu-17.04
+  driver:
+    image: dokken/ubuntu-17.04
+    pid_one_command: /bin/systemd
+  
 suites:
   - name: default
     run_list: test::default

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,6 +13,7 @@ platforms:
   - name: debian-8.8
   - name: ubuntu-14.04
   - name: ubuntu-16.04
+  - name: ubuntu-17.04
 
 suites:
   - name: default

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
   - INSTANCE=default-debian-8
   - INSTANCE=default-ubuntu-1404
   - INSTANCE=default-ubuntu-1604
+  - INSTANCE=default-ubuntu-1704
 
 before_script:
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,7 +17,23 @@
 # limitations under the License.
 #
 
-default['chef-apt-docker']['components'] = %w(main)
-default['chef-apt-docker']['uri'] = 'https://apt.dockerproject.org/repo'
-default['chef-apt-docker']['keyserver'] = 'pgp.mit.edu'
-default['chef-apt-docker']['key'] = '58118E89F3A912897C070ADBF76221572C52609D'
+default['chef-apt-docker']['docker-stable']['components'] = %w(stable)
+default['chef-apt-docker']['docker-stable']['uri'] = "https://download.docker.com/linux/#{node['platform']}"
+default['chef-apt-docker']['docker-stable']['distribution'] = node['lsb']['codename']
+default['chef-apt-docker']['docker-stable']['keyserver'] = 'pgp.mit.edu'
+default['chef-apt-docker']['docker-stable']['key'] = '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
+default['chef-apt-docker']['docker-stable']['enabled'] = true
+
+default['chef-apt-docker']['docker-edge']['components'] = %w(edge)
+default['chef-apt-docker']['docker-edge']['uri'] = "https://download.docker.com/linux/#{node['platform']}"
+default['chef-apt-docker']['docker-edge']['distribution'] = node['lsb']['codename']
+default['chef-apt-docker']['docker-edge']['keyserver'] = 'pgp.mit.edu'
+default['chef-apt-docker']['docker-edge']['key'] = '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
+default['chef-apt-docker']['docker-edge']['enabled'] = false
+
+default['chef-apt-docker']['docker-test']['components'] = %w(test)
+default['chef-apt-docker']['docker-test']['uri'] = "https://download.docker.com/linux/#{node['platform']}"
+default['chef-apt-docker']['docker-test']['distribution'] = node['lsb']['codename']
+default['chef-apt-docker']['docker-test']['keyserver'] = 'pgp.mit.edu'
+default['chef-apt-docker']['docker-test']['key'] = '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
+default['chef-apt-docker']['docker-test']['enabled'] = false

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,10 +17,15 @@
 # limitations under the License.
 #
 
-apt_repository 'docker' do
-  uri node['chef-apt-docker']['uri']
-  distribution "#{node['platform']}-#{node['lsb']['codename']}"
-  keyserver node['chef-apt-docker']['keyserver']
-  components node['chef-apt-docker']['components']
-  key node['chef-apt-docker']['key']
+%w(
+  docker-stable
+  docker-edge
+  docker-test
+).each do |repo|
+  apt_repository repo do
+    node['chef-apt-docker'][repo].each do |config, value|
+      send(config.to_sym, value) unless value.nil? || config == 'enabled'
+    end
+    action node['chef-apt-docker'][repo]['enabled'] ? :add : :remove
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,4 +5,9 @@ RSpec.configure do |config|
   config.color = true               # Use color in STDOUT
   config.formatter = :documentation # Use the specified formatter
   config.log_level = :error         # Avoid deprecation notice SPAM
+
+  # run all specs when using a filter, but no spec match
+  config.run_all_when_everything_filtered = true
+
+  Ohai::Config[:log_level] = :error
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -1,10 +1,21 @@
 require 'spec_helper'
 
-describe 'default recipe on ubuntu 16.04' do
-  let(:runner) { ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04') }
-  let(:chef_run) { runner.converge('chef-apt-docker::default') }
+describe 'chef-apt-docker::default' do
+  context 'default attributes' do
+    let(:chef_run) do
+      ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04').converge(described_recipe)
+    end
 
-  it 'converges successfully' do
-    expect { :chef_run }.to_not raise_error
+    it 'creates the apt repo docker-stable' do
+      expect(chef_run).to add_apt_repository('docker-stable')
+    end
+
+    it 'removes the apt repo docker-edge' do
+      expect(chef_run).to remove_apt_repository('docker-edge')
+    end
+
+    it 'removes the apt repo docker-test' do
+      expect(chef_run).to remove_apt_repository('docker-test')
+    end
   end
 end

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -1,11 +1,3 @@
 include_recipe 'chef-apt-docker'
 
-# docker needs init-system-helpers, which is in backports on wheezy
-apt_repository 'debian_wheezy_backports' do
-  uri 'http://http.debian.net/debian'
-  distribution 'wheezy-backports'
-  components %w(main)
-  only_if { node['lsb']['codename'] == 'wheezy' }
-end
-
-package 'docker-engine'
+package 'docker-ce'

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -1,8 +1,15 @@
-describe apt('https://apt.dockerproject.org/repo') do
-  it { should exist }
-  it { should be_enabled }
+if os[:name] == 'debian'
+  describe apt('https://download.docker.com/linux/debian') do
+    it { should exist }
+    it { should be_enabled }
+  end
+elsif os[:name] == 'ubuntu'
+  describe apt('https://download.docker.com/linux/ubuntu') do
+    it { should exist }
+    it { should be_enabled }
+  end
 end
 
-describe package('docker-engine') do
+describe package('docker-ce') do
   it { should be_installed }
 end


### PR DESCRIPTION
current repository being used is the docker-edge releases. this updates to the new docker repository url and allows enabling stable/edge/test. it also changes the default from docker-edge to docker-stable.