### PR TITLE
Allow Custom Repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Configures the official Docker apt repository
 ## Attributes
 
 - `node['chef-apt-docker']['components']` - repository components to configure. Default to ['main']. Other options are experimental and testing. Component must be an array of strings even if only a single component.
+- `node['chef-apt-docker']['repos']` - array of repos to add, useful for older docker versions
 
 ## Usage
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,3 +37,9 @@ default['chef-apt-docker']['docker-test']['distribution'] = node['lsb']['codenam
 default['chef-apt-docker']['docker-test']['keyserver'] = 'pgp.mit.edu'
 default['chef-apt-docker']['docker-test']['key'] = '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
 default['chef-apt-docker']['docker-test']['enabled'] = false
+
+default['chef-apt-docker']['repos'] = %w(
+  docker-stable
+  docker-edge
+  docker-test
+)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,11 +17,7 @@
 # limitations under the License.
 #
 
-%w(
-  docker-stable
-  docker-edge
-  docker-test
-).each do |repo|
+node['chef-apt-docker']['repos'].each do |repo|
   apt_repository repo do
     node['chef-apt-docker'][repo].each do |config, value|
       send(config.to_sym, value) unless value.nil? || config == 'enabled'


### PR DESCRIPTION
### Description

This commit allows a user to specify other repos to use, for example you
can get the old repo back with these attributes:

```
default['chef-apt-docker']['docker-legacy']['components'] = %w(main)
default['chef-apt-docker']['docker-legacy']['uri'] =
'https://apt.dockerproject.org/repo'
default['chef-apt-docker']['docker-legacy']['keyserver'] = 'pgp.mit.edu'
default['chef-apt-docker']['docker-legacy']['key'] =
'58118E89F3A912897C070ADBF76221572C52609D'
default['chef-apt-docker']['docker-legacy']['enabled'] = true
default['chef-apt-docker']['docker-legacy']['distribution'] =
'ubuntu-trusty'
default['chef-apt-docker']['docker-stable']['enabled'] = false
default['chef-apt-docker']['repos'] = %w(
  docker-stable
  docker-edge
  docker-test
  docker-legacy
)
```

### Issues Resolved

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
