### PR TITLE
Avoid potential NilClass error in attributes file

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,9 +17,11 @@
 # limitations under the License.
 #
 
+distribution = node['lsb'].nil? || node['lsb']['codename'].nil? ? '' : node['lsb']['codename']
+
 default['chef-apt-docker']['docker-stable']['components'] = %w(stable)
 default['chef-apt-docker']['docker-stable']['uri'] = "https://download.docker.com/linux/#{node['platform']}"
-default['chef-apt-docker']['docker-stable']['distribution'] = node['lsb']['codename']
+default['chef-apt-docker']['docker-stable']['distribution'] = distribution
 default['chef-apt-docker']['docker-stable']['arch'] = 'amd64'
 default['chef-apt-docker']['docker-stable']['keyserver'] = 'keyserver.ubuntu.com'
 default['chef-apt-docker']['docker-stable']['key'] = '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
@@ -27,7 +29,7 @@ default['chef-apt-docker']['docker-stable']['enabled'] = true
 
 default['chef-apt-docker']['docker-edge']['components'] = %w(edge)
 default['chef-apt-docker']['docker-edge']['uri'] = "https://download.docker.com/linux/#{node['platform']}"
-default['chef-apt-docker']['docker-edge']['distribution'] = node['lsb']['codename']
+default['chef-apt-docker']['docker-edge']['distribution'] = distribution
 default['chef-apt-docker']['docker-edge']['arch'] = 'amd64'
 default['chef-apt-docker']['docker-edge']['keyserver'] = 'keyserver.ubuntu.com'
 default['chef-apt-docker']['docker-edge']['key'] = '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'
@@ -35,7 +37,7 @@ default['chef-apt-docker']['docker-edge']['enabled'] = false
 
 default['chef-apt-docker']['docker-test']['components'] = %w(test)
 default['chef-apt-docker']['docker-test']['uri'] = "https://download.docker.com/linux/#{node['platform']}"
-default['chef-apt-docker']['docker-test']['distribution'] = node['lsb']['codename']
+default['chef-apt-docker']['docker-test']['distribution'] = distribution
 default['chef-apt-docker']['docker-test']['arch'] = 'amd64'
 default['chef-apt-docker']['docker-test']['keyserver'] = 'keyserver.ubuntu.com'
 default['chef-apt-docker']['docker-test']['key'] = '9DC858229FC7DD38854AE2D88D81803C0EBFCD88'


### PR DESCRIPTION
### Description

Add a nil check for node['lsb'] and node['lsb']['codename'] before setting the distribution attribute.

### Issues Resolved

This fixes a potential NilClass error that arises if the cookbook is compiled on a Windows box. 

We have a production environment cookbook with recipes for predominantly Linux nodes but a few Windows nodes as well. This cookbook causes a NilClass error in the compile stage because Windows boxes don't have a node['lsb'] attribute.