### PR TITLE
Added support for Ubuntu platform

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,7 +18,7 @@
 #
 
 package %w(dirmngr apt-transport-https) do
-  only_if { node['platform'] == 'debian' && node['platform_version'].to_i >= 9 }
+  only_if { node['platform'] == 'debian' || node['platform'] == 'ubuntu' && node['platform_version'].to_i >= 9 }
 end
 
 %w(


### PR DESCRIPTION
### Description

Changed the code to verify and install packages dirmngr and apt-transport-https where the node['platform'] is ubuntu or debain

### Issues Resolved

For Ubuntu operating Systems the node['platform'] is shown as 'ubuntu', as the existing code is only verifying for 'debian' the cookbook is failing to install  apt-transport-https package and is exiting while updating apt repositories.
Changed the code to check the output for both 'debain' and 'ubuntu'.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Signed-off-by: Saketh Jakkula <sakethjakkula642@gmail.com>